### PR TITLE
Added 'Transfer' event to ERC20_functions.sol

### DIFF
--- a/ERC20_functions.sol
+++ b/ERC20_functions.sol
@@ -7,6 +7,7 @@ contract ERC20CompatibleToken {
 
     mapping(address => uint) balances; // List of user balances.
 
+    event Transfer(address indexed from, address indexed to, uint value);
   	event Approval(address indexed owner, address indexed spender, uint256 value);
   	mapping (address => mapping (address => uint256)) internal allowed;
 


### PR DESCRIPTION
The call to 'Transfer' on line 29 was unresolved, causing compiler errors.
Adding a 'Transfer' event fixes this.