### PR TITLE
Deleted balances attribute from Token.sol

### DIFF
--- a/Token.sol
+++ b/Token.sol
@@ -11,8 +11,6 @@ import '././SafeMath.sol';
 contract ERC223Token is ERC223Interface, ERC20CompatibleToken {
     using SafeMath for uint;
 
-    mapping(address => uint) balances; // List of user balances.
-    
     /**
      * @dev Transfer the specified amount of tokens to the specified address.
      *      Invokes the `tokenFallback` function if the recipient is a contract.
@@ -42,7 +40,7 @@ contract ERC223Token is ERC223Interface, ERC20CompatibleToken {
         }
         Transfer(msg.sender, _to, _value, _data);
     }
-    
+
     /**
      * @dev Transfer the specified amount of tokens to the specified address.
      *      This function works the same with the previous one
@@ -70,7 +68,7 @@ contract ERC223Token is ERC223Interface, ERC20CompatibleToken {
         Transfer(msg.sender, _to, _value, empty);
     }
 
-    
+
     /**
      * @dev Returns balance of the `_owner`.
      *


### PR DESCRIPTION
In the current implementation, `ERC223Token` inherits from `ERC20CompatibleToken`, however, both contracts define a `balances` attribute. I am not sure this is an expected behavior, as it can lead to weird cases.

Take for instance the following code:
```
contract MyToken is ERC223Token {
     // Define your custom token's functions
     function setBalance(address _myAddress) public (bool) {
          balances[_myAddress] = 100;
          return true;
     }
}
```

Let's say I have 3 accounts in my running geth instance. All accounts have a lot of ethers on their balance, and `myTokenInstance` points to the `MyToken` contract I deployed.
In this case, if I do:
```
myTokenInstance.setBalance(eth.accounts[1])
```

Then the `balances` attribute of `ERC223Token` gets updated, and `eth.accounts[2]` has 100 tokens. **BUT** the change in the balance is not applied in regard of the `ERC20CompatibleToken` contract.

Then, if I do:
```
myTokenInstance.approve(eth.accounts[2], 50, {from: eth.accounts[1]})
myTokenInstance.transferFrom(eth.accounts[1], eth.accounts[2], 12, {from: eth.accounts[2]})
```
This will fail and trigger a `revert`. indeed, `transferFrom()` is defined in the `ERC20CompatibleToken` contract. However, the `balances` attribute used in `MyContract` comes from the `ERC223Token`, and thus, `balances` of the `ERc20CompatibleToken` has not been updated by the `setBalance()` function of `myToken`. This means that the 2nd require of the `transferFrom` (`require(_value <= balances[_from]);`) fails because `balances[_from])` is 0 in the context of the `ERC20CompatibleToken`.

Thus, eliminating the `balances` attribute from the `ERC223Token` contract fixed this bug and helps keeping a coherent global state.