### PR TITLE
- Updated pragma solidity to ^0.4.24;

### DIFF
--- a/SafeMath.sol
+++ b/SafeMath.sol
@@ -1,53 +1,44 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.4.24;
 
 
 /**
  * Math operations with safety checks
  */
 library SafeMath {
-  function mul(uint a, uint b) internal returns (uint) {
-    uint c = a * b;
+  function mul(uint a, uint b) internal pure returns (uint c) {
+    c = a * b;
     assert(a == 0 || c / a == b);
-    return c;
   }
 
-  function div(uint a, uint b) internal returns (uint) {
+  function div(uint a, uint b) internal pure returns (uint c) {
     // assert(b > 0); // Solidity automatically throws when dividing by 0
-    uint c = a / b;
+    c = a / b;
     // assert(a == b * c + a % b); // There is no case in which this doesn't hold
-    return c;
   }
 
-  function sub(uint a, uint b) internal returns (uint) {
+  function sub(uint a, uint b) internal pure returns (uint c) {
     assert(b <= a);
-    return a - b;
+    c = a - b;
   }
 
-  function add(uint a, uint b) internal returns (uint) {
-    uint c = a + b;
+  function add(uint a, uint b) internal pure returns (uint c) {
+    c = a + b;
     assert(c >= a);
-    return c;
   }
 
-  function max64(uint64 a, uint64 b) internal constant returns (uint64) {
+  function max64(uint64 a, uint64 b) internal pure returns (uint64) {
     return a >= b ? a : b;
   }
 
-  function min64(uint64 a, uint64 b) internal constant returns (uint64) {
+  function min64(uint64 a, uint64 b) internal pure returns (uint64) {
     return a < b ? a : b;
   }
 
-  function max256(uint256 a, uint256 b) internal constant returns (uint256) {
+  function max256(uint256 a, uint256 b) internal pure returns (uint256) {
     return a >= b ? a : b;
   }
 
-  function min256(uint256 a, uint256 b) internal constant returns (uint256) {
+  function min256(uint256 a, uint256 b) internal pure returns (uint256) {
     return a < b ? a : b;
-  }
-
-  function assert(bool assertion) internal {
-    if (!assertion) {
-      throw;
-    }
   }
 }

--- a/token/ERC223/ERC223_interface.sol
+++ b/token/ERC223/ERC223_interface.sol
@@ -1,9 +1,9 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.4.24;
 
 contract ERC223Interface {
     uint public totalSupply;
-    function balanceOf(address who) constant returns (uint);
-    function transfer(address to, uint value);
-    function transfer(address to, uint value, bytes data);
+    function balanceOf(address who) public view returns (uint);
+    function transfer(address to, uint value) public;
+    function transfer(address to, uint value, bytes data) public;
     event Transfer(address indexed from, address indexed to, uint value, bytes data);
 }

--- a/token/ERC223/ERC223_receiving_contract.sol
+++ b/token/ERC223/ERC223_receiving_contract.sol
@@ -1,10 +1,10 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.4.24;
 
  /**
  * @title Contract that will work with ERC223 tokens.
  */
- 
-contract ERC223ReceivingContract { 
+
+contract ERC223ReceivingContract {
 /**
  * @dev Standard ERC223 function that will handle incoming token transfers.
  *
@@ -12,5 +12,5 @@ contract ERC223ReceivingContract {
  * @param _value Amount of tokens.
  * @param _data  Transaction metadata.
  */
-    function tokenFallback(address _from, uint _value, bytes _data);
+    function tokenFallback(address _from, uint _value, bytes _data) public;
 }

--- a/token/ERC223/ERC223_token.sol
+++ b/token/ERC223/ERC223_token.sol
@@ -1,8 +1,8 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.4.24;
 
 import './ERC223_interface.sol';
 import './ERC223_receiving_contract.sol';
-import '././SafeMath.sol';
+import './SafeMath.sol';
 
 /**
  * @title Reference implementation of the ERC223 standard token.
@@ -11,7 +11,7 @@ contract ERC223Token is ERC223Interface {
     using SafeMath for uint;
 
     mapping(address => uint) balances; // List of user balances.
-    
+
     /**
      * @dev Transfer the specified amount of tokens to the specified address.
      *      Invokes the `tokenFallback` function if the recipient is a contract.
@@ -23,7 +23,7 @@ contract ERC223Token is ERC223Interface {
      * @param _value Amount of tokens that will be transferred.
      * @param _data  Transaction metadata.
      */
-    function transfer(address _to, uint _value, bytes _data) {
+    function transfer(address _to, uint _value, bytes _data) public {
         // Standard function transfer similar to ERC20 transfer with no _data .
         // Added due to backwards compatibility reasons .
         uint codeLength;
@@ -41,7 +41,7 @@ contract ERC223Token is ERC223Interface {
         }
         emit Transfer(msg.sender, _to, _value, _data);
     }
-    
+
     /**
      * @dev Transfer the specified amount of tokens to the specified address.
      *      This function works the same with the previous one
@@ -51,7 +51,7 @@ contract ERC223Token is ERC223Interface {
      * @param _to    Receiver address.
      * @param _value Amount of tokens that will be transferred.
      */
-    function transfer(address _to, uint _value) {
+    function transfer(address _to, uint _value) public {
         uint codeLength;
         bytes memory empty;
 
@@ -69,14 +69,14 @@ contract ERC223Token is ERC223Interface {
         emit Transfer(msg.sender, _to, _value, empty);
     }
 
-    
+
     /**
      * @dev Returns balance of the `_owner`.
      *
      * @param _owner   The address whose balance will be returned.
      * @return balance Balance of the `_owner`.
      */
-    function balanceOf(address _owner) constant returns (uint balance) {
+    function balanceOf(address _owner) public view returns (uint balance) {
         return balances[_owner];
     }
 }


### PR DESCRIPTION
This update deals with style changes and deprecated methods. It upgrades the current token definition to the ^0.4.24 standard such that no errors or warnings are thrown. It also reduces unnecessary lines of code to take advantage of newer language features.

- Replaced deprecated 'constant' with 'view' or 'pure' depending on context
- Added missing 'public' scopes to functions
- Removed 'assert' from SafeMath, which shadowed the assert function in Solidity that performs same action.
- Refactored SafeMath functions to remove unnecessary return arguments.