### PR TITLE
change uint to uint256

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ERC223 is a superset of the [ERC20](https://github.com/ethereum/EIPs/issues/20) 
 
 ```js
 contract ERC223 {
-  function transfer(address to, uint value, bytes data) {
+  function transfer(address to, uint256 value, bytes data) {
         uint codeLength;
         assembly {
             codeLength := extcodesize(_to)
@@ -54,7 +54,7 @@ contract ExampleReceiver is StandardReceiver {
     LogTokenPayable(tkn.addr, tkn.sender, tkn.value);
   }
 
-  event LogTokenPayable(address token, address sender, uint value);
+  event LogTokenPayable(address token, address sender, uint256 value);
 }
 ```
 

--- a/SafeMath.sol
+++ b/SafeMath.sol
@@ -5,26 +5,26 @@ pragma solidity ^0.4.11;
  * Math operations with safety checks
  */
 library SafeMath {
-  function mul(uint a, uint b) internal returns (uint) {
-    uint c = a * b;
+  function mul(unit256 a, unit256 b) internal returns (uint) {
+    unit256 c = a * b;
     assert(a == 0 || c / a == b);
     return c;
   }
 
-  function div(uint a, uint b) internal returns (uint) {
+  function div(unit256 a, unit256 b) internal returns (uint) {
     // assert(b > 0); // Solidity automatically throws when dividing by 0
-    uint c = a / b;
+    unit256 c = a / b;
     // assert(a == b * c + a % b); // There is no case in which this doesn't hold
     return c;
   }
 
-  function sub(uint a, uint b) internal returns (uint) {
+  function sub(unit256 a, unit256 b) internal returns (uint) {
     assert(b <= a);
     return a - b;
   }
 
-  function add(uint a, uint b) internal returns (uint) {
-    uint c = a + b;
+  function add(unit256 a, unit256 b) internal returns (uint) {
+    unit256 c = a + b;
     assert(c >= a);
     return c;
   }

--- a/token/ERC223/ERC223_interface.sol
+++ b/token/ERC223/ERC223_interface.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.4.11;
 
 contract ERC223Interface {
-    uint public totalSupply;
+    unit256 public totalSupply;
     function balanceOf(address who) constant returns (uint);
-    function transfer(address to, uint value);
-    function transfer(address to, uint value, bytes data);
-    event Transfer(address indexed from, address indexed to, uint value, bytes data);
+    function transfer(address to, unit256 value);
+    function transfer(address to, unit256 value, bytes data);
+    event Transfer(address indexed from, address indexed to, unit256 value, bytes data);
 }

--- a/token/ERC223/ERC223_receiving_contract.sol
+++ b/token/ERC223/ERC223_receiving_contract.sol
@@ -12,5 +12,5 @@ contract ERC223ReceivingContract {
  * @param _value Amount of tokens.
  * @param _data  Transaction metadata.
  */
-    function tokenFallback(address _from, uint _value, bytes _data);
+    function tokenFallback(address _from, unit256 _value, bytes _data);
 }

--- a/token/ERC223/ERC223_token.sol
+++ b/token/ERC223/ERC223_token.sol
@@ -8,9 +8,9 @@ import '././SafeMath.sol';
  * @title Reference implementation of the ERC223 standard token.
  */
 contract ERC223Token is ERC223Interface {
-    using SafeMath for uint;
+    using SafeMath for uint256;
 
-    mapping(address => uint) balances; // List of user balances.
+    mapping(address => uint256) balances; // List of user balances.
     
     /**
      * @dev Transfer the specified amount of tokens to the specified address.
@@ -23,7 +23,7 @@ contract ERC223Token is ERC223Interface {
      * @param _value Amount of tokens that will be transferred.
      * @param _data  Transaction metadata.
      */
-    function transfer(address _to, uint _value, bytes _data) {
+    function transfer(address _to, unit256 _value, bytes _data) {
         // Standard function transfer similar to ERC20 transfer with no _data .
         // Added due to backwards compatibility reasons .
         uint codeLength;
@@ -51,7 +51,7 @@ contract ERC223Token is ERC223Interface {
      * @param _to    Receiver address.
      * @param _value Amount of tokens that will be transferred.
      */
-    function transfer(address _to, uint _value) {
+    function transfer(address _to, unit256 _value) {
         uint codeLength;
         bytes memory empty;
 
@@ -76,7 +76,7 @@ contract ERC223Token is ERC223Interface {
      * @param _owner   The address whose balance will be returned.
      * @return balance Balance of the `_owner`.
      */
-    function balanceOf(address _owner) constant returns (uint balance) {
+    function balanceOf(address _owner) constant returns (unit256 balance) {
         return balances[_owner];
     }
 }


### PR DESCRIPTION
ERC20 has uint256 numbers. 
I changed all numbers from unit to uint256 to be compatible with ERC20.