### PR TITLE
add indexed keyword in Transfer event

### DIFF
--- a/token/ERC223/ERC223_interface.sol
+++ b/token/ERC223/ERC223_interface.sol
@@ -5,5 +5,5 @@ contract ERC223Interface {
     function balanceOf(address who) constant returns (uint);
     function transfer(address to, uint value);
     function transfer(address to, uint value, bytes data);
-    event Transfer(address indexed from, address indexed to, uint value, bytes data);
+    event Transfer(address indexed from, address indexed to, uint indexed value, bytes data);
 }


### PR DESCRIPTION
According to [ERC223 token standard](https://github.com/ethereum/EIPs/issues/223) _value_ variable has _indexed_ keyword: 
`event Transfer(address indexed _from, address indexed _to, uint256 indexed _value, bytes _data)`
So this PR adds _indexed_ keyword in Transfer event.