### PR TITLE
Edited for Solidity 0.8.0

### DIFF
--- a/token/ERC223/ERC223.sol
+++ b/token/ERC223/ERC223.sol
@@ -1,16 +1,13 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.8.0;
 
 import "./IERC223.sol";
 import "./IERC223Recipient.sol";
-import "../../math/SafeMath.sol";
 import "../../utils/Address.sol";
 
 /**
  * @title Reference implementation of the ERC223 standard token.
  */
 contract ERC223Token is IERC223 {
-    using SafeMath for uint;
-
     /**
      * @dev See `IERC223.totalSupply`.
      */
@@ -34,8 +31,8 @@ contract ERC223Token is IERC223 {
     function transfer(address _to, uint _value, bytes memory _data) public returns (bool success){
         // Standard function transfer similar to ERC20 transfer with no _data .
         // Added due to backwards compatibility reasons .
-        balances[msg.sender] = balances[msg.sender].sub(_value);
-        balances[_to] = balances[_to].add(_value);
+        balances[msg.sender] = balances[msg.sender] - _value;
+        balances[_to] = balances[_to] + _value;
         if(Address.isContract(_to)) {
             IERC223Recipient receiver = IERC223Recipient(_to);
             receiver.tokenFallback(msg.sender, _value, _data);
@@ -55,8 +52,8 @@ contract ERC223Token is IERC223 {
      */
     function transfer(address _to, uint _value) public returns (bool success){
         bytes memory empty = hex"00000000";
-        balances[msg.sender] = balances[msg.sender].sub(_value);
-        balances[_to] = balances[_to].add(_value);
+        balances[msg.sender] = balances[msg.sender] - _value;
+        balances[_to] = balances[_to] + _value;
         if(Address.isContract(_to)) {
             IERC223Recipient receiver = IERC223Recipient(_to);
             receiver.tokenFallback(msg.sender, _value, empty);

--- a/token/ERC223/ERC223Burnable.sol
+++ b/token/ERC223/ERC223Burnable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.8.0;
 
 import "./ERC223.sol";
 
@@ -14,8 +14,8 @@ contract ERC223Burnable is ERC223Token {
      * See {ERC20-_burn}.
      */
     function burn(uint256 _amount) public {
-        balances[msg.sender] = balances[msg.sender].sub(_amount);
-        _totalSupply = _totalSupply.sub(_amount);
+        balances[msg.sender] = balances[msg.sender] - _amount;
+        _totalSupply = _totalSupply - _amount;
         
         bytes memory empty = hex"00000000";
         emit Transfer(msg.sender, address(0), _amount, empty);

--- a/token/ERC223/ERC223Mintable.sol
+++ b/token/ERC223/ERC223Mintable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.8.0;
 
 import "./ERC223.sol";
 
@@ -53,8 +53,8 @@ contract ERC223Mintable is ERC223Token {
      * - the caller must have the {MinterRole}.
      */
     function mint(address account, uint256 amount) public onlyMinter returns (bool) {
-        balances[account] = balances[account].add(amount);
-        _totalSupply = _totalSupply.add(amount);
+        balances[account] = balances[account] + amount;
+        _totalSupply = _totalSupply + amount;
         
         bytes memory empty = hex"00000000";
         emit Transfer(address(0),account, amount, empty);

--- a/token/ERC223/IERC223.sol
+++ b/token/ERC223/IERC223.sol
@@ -1,5 +1,4 @@
-    
-pragma solidity ^0.5.1;
+pragma solidity ^0.8.0;
 
 /**
  * @dev Interface of the ERC777Token standard as defined in the EIP.

--- a/token/ERC223/IERC223Recipient.sol
+++ b/token/ERC223/IERC223Recipient.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity ^0.8.0;
 
  /**
  * @title Contract that will work with ERC223 tokens.


### PR DESCRIPTION
In Solidity 0.8.0 you don't have to use SafeMath. You can [check it](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). I think an update will be good for project.